### PR TITLE
chore(renovate): automerge stackit sdk minor + patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,9 +40,11 @@
       "groupName": "libnuke"
     },
     {
-      "description": "STACKIT SDK — manual, own PR so it doesn't block the group's automerge",
+      "description": "STACKIT SDK — own PR (easy to bisect/revert), auto-merged for minor + patch. Majors still gated by the gomod major rule above.",
       "matchPackageNames": ["github.com/stackitcloud/**"],
-      "automerge": false,
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
       "groupName": "stackit sdk"
     }
   ],


### PR DESCRIPTION
Flips the `stackit sdk` group from manual to automerge for minor/patch so PRs like #88 merge on their own once CI is green. Majors remain gated by the gomod major rule (dashboard approval, no automerge).